### PR TITLE
fix(indexer): use deadpool connection pool to prevent db connection drops (#91)

### DIFF
--- a/apps/indexer/Cargo.lock
+++ b/apps/indexer/Cargo.lock
@@ -196,6 +196,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-postgres"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
+dependencies = [
+ "async-trait",
+ "deadpool",
+ "getrandom 0.2.17",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "diesel"
 version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +466,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -726,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +854,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1216,6 +1273,7 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
+ "deadpool-postgres",
  "diesel",
  "reqwest",
  "serde",
@@ -1556,7 +1614,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/apps/indexer/Cargo.toml
+++ b/apps/indexer/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.150"
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread", "time", "net", "io-util"] }
 tokio-postgres = { version = "0.7.17", features = ["with-chrono-0_4", "with-serde_json-1"] }
+deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }

--- a/apps/indexer/src/main.rs
+++ b/apps/indexer/src/main.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, env, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, NaiveDateTime, Utc};
+use deadpool_postgres::{ManagerConfig, Pool, RecyclingMethod, Runtime};
 use reqwest::Client as HttpClient;
 use sentinel_indexer::handlers::retry_rpc;
 use sentinel_indexer::models::IncomingTurretEvent;
@@ -11,7 +12,7 @@ use serde_json::{json, Value};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::time::{interval, Duration};
-use tokio_postgres::{Client as PgClient, NoTls};
+use tokio_postgres::NoTls;
 
 const DEFAULT_POLL_INTERVAL_MS: u64 = 5_000;
 const DEFAULT_PAGE_SIZE: u64 = 50;
@@ -100,25 +101,37 @@ struct PageOutcome {
 }
 
 struct Database {
-    client: PgClient,
+    pool: Pool,
 }
 
 impl Database {
     async fn connect(database_url: &str) -> Result<Self> {
-        let (client, connection) = tokio_postgres::connect(database_url, NoTls).await?;
-        tokio::spawn(async move {
-            if let Err(error) = connection.await {
-                eprintln!("postgres connection error: {error}");
-            }
+        let mut config = deadpool_postgres::Config::new();
+        config.url = Some(database_url.to_string());
+        config.manager = Some(ManagerConfig {
+            recycling_method: RecyclingMethod::Fast,
         });
 
-        let database = Self { client };
+        let pool_size = env::var("DATABASE_POOL_SIZE")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(4);
+        config.pool = Some(deadpool_postgres::PoolConfig::new(pool_size));
+
+        let pool = config.create_pool(Some(Runtime::Tokio1), NoTls)?;
+
+        let database = Self { pool };
         database.ensure_schema().await?;
         Ok(database)
     }
 
     async fn ensure_schema(&self) -> Result<()> {
-        self.client
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to check out database connection")?;
+        client
             .batch_execute(
                 r#"
                 CREATE TABLE IF NOT EXISTS turret_events (
@@ -146,8 +159,12 @@ impl Database {
     }
 
     async fn load_state(&self, pipeline_name: &str) -> Result<CursorState> {
-        let row = self
-            .client
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to check out database connection")?;
+        let row = client
             .query_opt(
                 r#"
                 SELECT cursor_tx_digest, cursor_event_seq, last_checkpoint_sequence_number
@@ -188,7 +205,12 @@ impl Database {
             .map(|cursor| cursor.tx_digest.as_str());
         let cursor_event_seq = state.cursor.as_ref().map(|cursor| cursor.event_seq);
 
-        self.client
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to check out database connection")?;
+        client
             .execute(
                 r#"
                 INSERT INTO indexer_cursors (
@@ -220,7 +242,12 @@ impl Database {
     }
 
     async fn insert_event(&self, event: &IncomingTurretEvent) -> Result<()> {
-        self.client
+        let client = self
+            .pool
+            .get()
+            .await
+            .context("failed to check out database connection")?;
+        client
             .execute(
                 r#"
                 INSERT INTO turret_events (


### PR DESCRIPTION
Closes #91. Replaces raw tokio-postgres client with deadpool-postgres to transparently handle dropped connections.