### PR TITLE
chore(docker): optimize api and dashboard images

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -9,9 +9,21 @@ FROM    deps AS build
 COPY    . .
 RUN     bun run --filter @sentinel/api test
 
+FROM    docker.io/oven/bun:1.3.14 AS prod-deps
+WORKDIR /app
+COPY    package.json bun.lock tsconfig.base.json tsconfig.json ./
+COPY    apps/api/package.json apps/api/package.json
+COPY    packages/shared-types/package.json packages/shared-types/package.json
+RUN     bun install --production
+
 FROM    docker.io/oven/bun:1.3.14 AS runner
 WORKDIR /app
-COPY    --from=build /app /app
+COPY    --from=prod-deps /app/node_modules ./node_modules
+COPY    package.json bun.lock tsconfig.base.json tsconfig.json ./
+COPY    apps/api/package.json ./apps/api/package.json
+COPY    packages/shared-types/package.json ./packages/shared-types/package.json
+COPY    apps/api/src ./apps/api/src
+COPY    packages/shared-types/src ./packages/shared-types/src
 ENV     PORT=3001
 EXPOSE  3001
 USER    bun

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -17,9 +17,21 @@ ENV     SENTINEL_BUILD_RELEASE_TAG=${SENTINEL_BUILD_RELEASE_TAG}
 COPY    . .
 RUN     bun run --filter @sentinel/dashboard build
 
+FROM    docker.io/oven/bun:1.3.14 AS prod-deps
+WORKDIR /app
+COPY    package.json bun.lock tsconfig.base.json tsconfig.json ./
+COPY    apps/dashboard/package.json apps/dashboard/package.json
+COPY    packages/shared-types/package.json packages/shared-types/package.json
+RUN     bun install --production
+
 FROM    docker.io/oven/bun:1.3.14 AS runner
 WORKDIR /app
-COPY    --from=build /app /app
+COPY    --from=prod-deps /app/node_modules ./node_modules
+COPY    package.json bun.lock tsconfig.base.json tsconfig.json ./
+COPY    apps/dashboard/package.json ./apps/dashboard/package.json
+COPY    packages/shared-types/package.json ./packages/shared-types/package.json
+COPY    --from=build /app/apps/dashboard/dist ./apps/dashboard/dist
+COPY    --from=build /app/apps/dashboard/server.ts ./apps/dashboard/server.ts
 EXPOSE  5173
 USER    bun
 CMD     ["bun", "apps/dashboard/server.ts"]


### PR DESCRIPTION
Resolves #32 by extracting production dependency installation into a separate stage and only copying necessary runtime files to the final runner images.